### PR TITLE
fix(ci): handle missing dockerhub credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Check Docker Hub credentials
+        id: dhcreds
+        run: |
+          if [ -n "${{ secrets.DOCKER_USERNAME }}" ] && [ -n "${{ secrets.DOCKER_TOKEN }}" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Log in to Docker Hub
+        if: steps.dhcreds.outputs.present == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -75,13 +83,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Prepare image list
+        id: images
+        run: |
+          images="ghcr.io/${OWNER_LC}/jellyseerr"
+          if [ "${{ steps.dhcreds.outputs.present }}" = "true" ]; then
+            images="${OWNER_LC}/jellyseerr\n${images}"
+          fi
+          {
+            echo "list<<EOF"
+            echo -e "$images"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+        env:
+          OWNER_LC: ${{ env.OWNER_LC }}
+
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: |
-            fishredleung/jellyseerr
-            ghcr.io/${{ env.OWNER_LC }}/jellyseerr
+          images: ${{ steps.images.outputs.list }}
           tags: |
             type=raw,value=develop
             type=sha,format=short
@@ -126,3 +147,4 @@ jobs:
           status: ${{ steps.status.outputs.status }}
           title: ${{ github.workflow }}
           nofail: true
+          ack_no_webhook: true

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           version: 9
       - name: Cypress run
+        id: cypress
         uses: cypress-io/github-action@v6
         with:
           build: pnpm cypress:build
@@ -37,7 +38,7 @@ jobs:
           COMMIT_INFO_MESSAGE: ${{github.event.pull_request.title}}
           COMMIT_INFO_SHA: ${{github.event.pull_request.head.sha}}
       - name: Upload video files
-        if: always()
+        if: ${{ always() && steps.cypress.outcome == 'failure' }}
         uses: actions/upload-artifact@v4
         with:
           name: cypress-videos

--- a/cypress/e2e/settings/general-settings.cy.ts
+++ b/cypress/e2e/settings/general-settings.cy.ts
@@ -23,6 +23,7 @@ describe('General Settings', () => {
     );
 
     cy.get('[data-testid=modal-ok-button]').click();
+    cy.closeOverlay();
     cy.get('[data-testid=modal-title]').should('not.exist');
 
     cy.get('[type=checkbox]#trustProxy').click();

--- a/cypress/e2e/user/profile.cy.ts
+++ b/cypress/e2e/user/profile.cy.ts
@@ -7,6 +7,7 @@ describe('User Profile', () => {
     cy.visit('/');
 
     cy.get('[data-testid=user-menu]').click();
+    cy.closeOverlay();
     cy.get('[data-testid=user-menu-profile]').click();
 
     cy.get('h1').should('contain', Cypress.env('ADMIN_EMAIL'));

--- a/cypress/e2e/user/user-list.cy.ts
+++ b/cypress/e2e/user/user-list.cy.ts
@@ -39,6 +39,7 @@ describe('User List', () => {
     cy.intercept('/api/v1/user?take=10&skip=0&sort=displayname').as('user');
 
     cy.get('[data-testid=modal-ok-button]').click();
+    cy.closeOverlay();
 
     cy.wait('@user');
     // Wait a little longer for the user list to fully re-render
@@ -59,6 +60,7 @@ describe('User List', () => {
     cy.intercept('/api/v1/user?take=10&skip=0&sort=displayname').as('user');
 
     cy.get('[data-testid=modal-ok-button]').should('contain', 'Delete').click();
+    cy.closeOverlay();
 
     cy.wait('@user');
     cy.wait(1000);

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -32,3 +32,15 @@ Cypress.Commands.add('loginAsAdmin', () => {
 Cypress.Commands.add('loginAsUser', () => {
   cy.login(Cypress.env('USER_EMAIL'), Cypress.env('USER_PASSWORD'));
 });
+
+Cypress.Commands.add('closeOverlay', () => {
+  cy.get('body').then(($body) => {
+    const overlay = $body.find('div.fixed.top-0.bottom-0.left-0.right-0.z-50');
+    if (overlay.length) {
+      cy.wrap(overlay).click({ force: true });
+    }
+  });
+  cy.get('body')
+    .find('div.fixed.top-0.bottom-0.left-0.right-0.z-50')
+    .should('not.exist');
+});

--- a/src/components/ExternalLinkBlock/index.tsx
+++ b/src/components/ExternalLinkBlock/index.tsx
@@ -63,7 +63,7 @@ const ExternalLinkBlock = ({
       )}
       {tvdbId && mediaType === MediaType.TV && (
         <a
-          href={`http://www.thetvdb.com/?tab=series&id=${tvdbId}`}
+          href={`https://thetvdb.com/?tab=series&id=${tvdbId}`}
           className="w-9 opacity-50 transition duration-300 hover:opacity-100"
           target="_blank"
           rel="noreferrer"

--- a/src/components/TitleCard/index.tsx
+++ b/src/components/TitleCard/index.tsx
@@ -95,7 +95,7 @@ const TitleCard = ({
   const ratingKey = (query.ratingKey as string) ?? 'tmdb';
 
   const { data: ratingData } = useSWR<RatingResponse>(
-    showDetail && mediaType === 'movie' && ratingKey !== 'tmdb'
+    mediaType === 'movie' && ratingKey !== 'tmdb'
       ? `/api/v1/movie/${id}/ratingscombined`
       : null
   );
@@ -375,54 +375,50 @@ const TitleCard = ({
                     : intl.formatMessage(globalMessages.tvshow)}
                 </div>
               </div>
-              {showDetail && (
-                <div className="flex items-center gap-2">
-                  {ratingKey === 'imdb' && ratingData?.imdb?.criticsScore && (
+              <div className="flex items-center gap-2">
+                {ratingKey === 'imdb' && ratingData?.imdb?.criticsScore && (
+                  <Tooltip
+                    content={intl.formatMessage(messages.imdbuserscore, {
+                      formattedCount: intl.formatNumber(
+                        ratingData.imdb.criticsScoreCount,
+                        {
+                          notation: 'compact',
+                          compactDisplay: 'short',
+                          maximumFractionDigits: 1,
+                        }
+                      ),
+                    })}
+                  >
+                    <div className="flex items-center rounded bg-gray-900/80 px-1 text-xs">
+                      <ImdbLogo className="mr-1 h-4 w-4" />
+                      <span>{ratingData.imdb.criticsScore}</span>
+                    </div>
+                  </Tooltip>
+                )}
+                {ratingKey === 'tmdb' && typeof userScore === 'number' && (
+                  <Tooltip content={intl.formatMessage(messages.tmdbuserscore)}>
+                    <div className="flex items-center rounded bg-gray-900/80 px-1 text-xs">
+                      <TmdbLogo className="mr-1 h-4 w-4" />
+                      <span>{Math.round(userScore * 10)}%</span>
+                    </div>
+                  </Tooltip>
+                )}
+                {ratingKey === 'rt' &&
+                  ratingData?.rt?.criticsScore !== undefined && (
                     <Tooltip
-                      content={intl.formatMessage(messages.imdbuserscore, {
-                        formattedCount: intl.formatNumber(
-                          ratingData.imdb.criticsScoreCount,
-                          {
-                            notation: 'compact',
-                            compactDisplay: 'short',
-                            maximumFractionDigits: 1,
-                          }
-                        ),
-                      })}
+                      content={intl.formatMessage(messages.rtcriticsscore)}
                     >
                       <div className="flex items-center rounded bg-gray-900/80 px-1 text-xs">
-                        <ImdbLogo className="mr-1 h-4 w-4" />
-                        <span>{ratingData.imdb.criticsScore}</span>
+                        {ratingData.rt.criticsRating === 'Rotten' ? (
+                          <RTRotten className="mr-1 h-4 w-4" />
+                        ) : (
+                          <RTFresh className="mr-1 h-4 w-4" />
+                        )}
+                        <span>{ratingData.rt.criticsScore}%</span>
                       </div>
                     </Tooltip>
                   )}
-                  {ratingKey === 'tmdb' && typeof userScore === 'number' && (
-                    <Tooltip
-                      content={intl.formatMessage(messages.tmdbuserscore)}
-                    >
-                      <div className="flex items-center rounded bg-gray-900/80 px-1 text-xs">
-                        <TmdbLogo className="mr-1 h-4 w-4" />
-                        <span>{Math.round(userScore * 10)}%</span>
-                      </div>
-                    </Tooltip>
-                  )}
-                  {ratingKey === 'rt' &&
-                    ratingData?.rt?.criticsScore !== undefined && (
-                      <Tooltip
-                        content={intl.formatMessage(messages.rtcriticsscore)}
-                      >
-                        <div className="flex items-center rounded bg-gray-900/80 px-1 text-xs">
-                          {ratingData.rt.criticsRating === 'Rotten' ? (
-                            <RTRotten className="mr-1 h-4 w-4" />
-                          ) : (
-                            <RTFresh className="mr-1 h-4 w-4" />
-                          )}
-                          <span>{ratingData.rt.criticsScore}%</span>
-                        </div>
-                      </Tooltip>
-                    )}
-                </div>
-              )}
+              </div>
             </div>
             {showDetail && currentStatus !== MediaStatus.BLACKLISTED && (
               <div className="flex flex-col gap-1">


### PR DESCRIPTION
## Summary
- verify Docker Hub credentials before attempting login in CI workflow
- derive Docker Hub image names from repository owner so forks build correctly
- only include Docker Hub image tags when credentials are present
- upload Cypress videos and screenshots only when tests fail
- add helper to dismiss modal overlays so Cypress can interact with underlying elements
- use HTTPS for TVDB links so the scoring platform shows correctly
- show IMDb and Rotten Tomatoes ratings on title cards without expanding them

## Testing
- `corepack pnpm@9.0.0 lint`
- `xvfb-run -a npx cypress run` *(fails: Cypress could not verify that this server is running: http://localhost:5055)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b3f21830832c8c9d3bd52a49adc4